### PR TITLE
fix gitter href

### DIFF
--- a/_data/chat.yml
+++ b/_data/chat.yml
@@ -5,7 +5,7 @@ channels:
    - title: General REMIX
      href: https://gitter.im/ethereum/remix
    - title: REMIX Development
-     href: https://gitter.im/ethereum/remix
+     href: https://gitter.im/ethereum/remix-dev
    - title: PLUGIN Development
      href: https://gitter.im/ethereum/remix-dev-plugin
    - title: Workshops


### PR DESCRIPTION
The gitter chat link of **remix development** is same to **general remix**. It shoud be https://gitter.im/ethereum/remix-dev @yann300 @ioedeveloper @bunsenstraat 